### PR TITLE
Fix service selector in PGVector deployment

### DIFF
--- a/pgvector_deployment/04_services.yaml
+++ b/pgvector_deployment/04_services.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql
 spec:
   selector:
-    name: postgresql
+    app: postgresql
   ports:
     - name: postgresql
       protocol: TCP


### PR DESCRIPTION
Service selector does not match the deployment's `app` label so the service is not able to find the postgres pod.