### PR TITLE
hf-tgi custom runtime untime fixes to enable metrics and avoid warning logs

### DIFF
--- a/hf_tgi_runtime/README.md
+++ b/hf_tgi_runtime/README.md
@@ -22,6 +22,8 @@ This runtime can be used in the exact same way as the out of the box ones:
 - Make sure you have added a GPU to your GPU configuration, that you have enough VRAM (GPU memory) to load the model, and that you have enough standard memory (RAM). Although the model loads into the GPU, RAM is still used for the pre-loading operations.
 - Once the model is loaded, you can access the inference endpoint provided through the dashboard.
 
+Note: Model files must contain the model weights in .safetensors format. Normally HF TGI will convert .bin to .safetensor at runtime if they are unavailable, but because the /mnt/models directory is not writeable this will fail. You can do this conversion offline before copying your model files to the object store.
+
 ## Usage
 
 Curl, Python, and GUI  examples are provided [here](https://huggingface.co/docs/text-generation-inference/basic_tutorials/consuming_tgi).

--- a/hf_tgi_runtime/hf-tgi-runtime.yaml
+++ b/hf_tgi_runtime/hf-tgi-runtime.yaml
@@ -1,10 +1,6 @@
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
-labels:
-  opendatahub.io/dashboard: "true"
 metadata:
-  annotations:
-    openshift.io/display-name: "HF-TGI"
   name: hf-tgi-runtime
 spec:
   containers:
@@ -13,26 +9,33 @@ spec:
       command: ["text-generation-launcher"]
       args:
         - "--model-id=/mnt/models/"
-        - "--port=8080"
+        - "--port=3000"
+      env:
+      - name: HF_HOME
+        value: /tmp/hf_home
+      - name: HUGGINGFACE_HUB_CACHE
+        value: /tmp/hf_hub_cache
+      - name: TRANSFORMER_CACHE
+        value: /tmp/transformers_cache
       #resources: # configure as required
       #  requests:
       #    nvidia.com/gpu: 1
       #  limits:
       #    nvidia.com/gpu: 1
-      readinessProbe:
+      readinessProbe: # Use exec probes instad of httpGet since the probes' port gets rewritten to the containerPort
         exec:
           command:
             - curl
-            - localhost:8080/health
+            - localhost:3000/health
         initialDelaySeconds: 30
       livenessProbe:
         exec:
           command:
             - curl
-            - localhost:8080/health
+            - localhost:3000/health
         initialDelaySeconds: 30
       ports:
-        - containerPort: 8080
+        - containerPort: 3000
           protocol: TCP
   multiModel: false
   supportedModelFormats:


### PR DESCRIPTION
This PR enables metrics by switching HF TGI to use port 3000. Currently a Service and ServiceMonitor is created for the IBM/TGIS runtime which exposes metrics on port 3000. We can make Prometheus scrape HF TGI metrics by using the same port in this custom runtime.

Also added a note about safetensor format in the README, and added some ENV vars to avoid silence some warning logs.