### PR TITLE
Minor milvus fixes

### DIFF
--- a/examples/ui/gradio/gradio-hftgi-rag-milvus/README.md
+++ b/examples/ui/gradio/gradio-hftgi-rag-milvus/README.md
@@ -1,6 +1,6 @@
-# Gradio UI for RAG using Hugging Face Text Generation Inference server and PostgreSQL+pgvector
+# Gradio UI for RAG using Hugging Face Text Generation Inference server and Milvus
 
-This is a simple UI example for a RAG-based Chatbot using Gradio, Hugging Face TGI server, and PostgreSQL+pgvector as a vector database.
+This is a simple UI example for a RAG-based Chatbot using Gradio, Hugging Face TGI server, and Milvus as a vector database.
 
 You can refer to those different notebooks to get a better understanding of the flow:
 

--- a/examples/ui/gradio/gradio-hftgi-rag-milvus/app.py
+++ b/examples/ui/gradio/gradio-hftgi-rag-milvus/app.py
@@ -112,7 +112,7 @@ embeddings = HuggingFaceEmbeddings(
 )
 
 stores = {}
-for collection in collections_data:
+for collection in collections_data["collections"]:
     stores[collection['name']] = Milvus(
         embedding_function=embeddings,
         connection_args={"host": MILVUS_HOST, "port": MILVUS_PORT, "user": MILVUS_USERNAME, "password": MILVUS_PASSWORD},
@@ -154,7 +154,7 @@ QA_CHAIN_PROMPT = PromptTemplate.from_template(template)
 
 
 qa_chain = {}
-for collection in collections_data:
+for collection in collections_data["collections"]:
     qa_chain[collection['name']] = RetrievalQA.from_chain_type(
         llm,
         retriever = stores[collection['name']].as_retriever(

--- a/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/deployment.yaml
+++ b/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/deployment.yaml
@@ -1,19 +1,19 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: gradio-hftgi-rag-pgvector
+  name: gradio-hftgi-rag-milvus
   labels:
-    app: gradio-hftgi-rag-pgvector
+    app: gradio-hftgi-rag-milvus
 spec:
   replicas: 0
   selector:
     matchLabels:
-      app: gradio-hftgi-rag-pgvector
+      app: gradio-hftgi-rag-milvus
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: gradio-hftgi-rag-pgvector
+        app: gradio-hftgi-rag-milvus
     spec:
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -98,7 +98,7 @@ spec:
             successThreshold: 1
             failureThreshold: 24
           terminationMessagePolicy: File
-          image: 'quay.io/rh-aiservices-bu/gradio-hftgi-rag-pgvector:latest'
+          image: 'quay.io/rh-aiservices-bu/gradio-hftgi-rag-milvus:latest'
           volumeMounts:
             - name: collections
               mountPath: /opt/app-root/src/collections.json

--- a/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/route.yaml
+++ b/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/route.yaml
@@ -1,13 +1,13 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: gradio-hftgi-rag-pgvector
+  name: gradio-hftgi-rag-milvus
   labels:
-    app: gradio-hftgi-rag-pgvector
+    app: gradio-hftgi-rag-milvus
 spec:
   to:
     kind: Service
-    name: gradio-hftgi-rag-pgvector
+    name: gradio-hftgi-rag-milvus
     weight: 100
   port:
     targetPort: http

--- a/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/service.yaml
+++ b/examples/ui/gradio/gradio-hftgi-rag-milvus/deployment/service.yaml
@@ -1,9 +1,9 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: gradio-hftgi-rag-pgvector
+  name: gradio-hftgi-rag-milvus
   labels:
-    app: gradio-hftgi-rag-pgvector
+    app: gradio-hftgi-rag-milvus
 spec:
   clusterIP: None
   ipFamilies:
@@ -17,4 +17,4 @@ spec:
   ipFamilyPolicy: SingleStack
   sessionAffinity: None
   selector:
-    app: gradio-hftgi-rag-pgvector
+    app: gradio-hftgi-rag-milvus

--- a/vector-databases/milvus/milvus_manifest_standalone.yaml
+++ b/vector-databases/milvus/milvus_manifest_standalone.yaml
@@ -180,7 +180,7 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
   labels:
-    helm.sh/chart: milvus-4.1.19
+    helm.sh/chart: milvus-4.1.21
     app.kubernetes.io/name: milvus
     app.kubernetes.io/instance: vectordb
     app.kubernetes.io/version: "2.3.10"
@@ -274,7 +274,7 @@ kind: Service
 metadata:
   name: vectordb-milvus
   labels:
-    helm.sh/chart: milvus-4.1.19
+    helm.sh/chart: milvus-4.1.21
     app.kubernetes.io/name: milvus
     app.kubernetes.io/instance: vectordb
     app.kubernetes.io/version: "2.3.10"
@@ -401,7 +401,7 @@ kind: Deployment
 metadata:
   name: vectordb-milvus-standalone
   labels:
-    helm.sh/chart: milvus-4.1.19
+    helm.sh/chart: milvus-4.1.21
     app.kubernetes.io/name: milvus
     app.kubernetes.io/instance: vectordb
     app.kubernetes.io/version: "2.3.10"


### PR DESCRIPTION
cc @guimou 

Some things I didn't include in the PR that I needed to do (but wasn't sure if they would fit):

1) I updated `configmap-collections.yaml` to have just one element with a name matching the collection that was created by the `milvus-ingest` notebook.
2) Related, the variable in line 39 is hardcoded. It's probably better to parametrize it from the deployment yaml itself. While I was hacking around I just changed it to `demo_collection` (as per the notebook)
3) An image needs to be pushed up to the official quay repo.
4) I didn't realise that the inference server url (line 55 in the deployment.yaml) needs to include the protocol as well as the port. Not a bit deal, but probably worth calling out in the docs.
5) I didn't get it to work with https/ssl. I admittedly didn't spend a ton of time on it.

Overall, thank you very much for this! I've learned a lot :-)
