### PR TITLE
updating gradio-rag-vllm-pgvector deployment image tag

### DIFF
--- a/examples/ui/gradio/gradio-rag-vllm-pgvector/deployment/deployment.yaml
+++ b/examples/ui/gradio/gradio-rag-vllm-pgvector/deployment/deployment.yaml
@@ -94,7 +94,7 @@ spec:
             successThreshold: 1
             failureThreshold: 24
           terminationMessagePolicy: File
-          image: 'quay.io/rh-aiservices-bu/gradio-rag-vllm-pgvector:latest'
+          image: 'quay.io/rh-aiservices-bu/gradio-rag-vllm-pgvector:0.0.1'
       dnsPolicy: ClusterFirst
   strategy:
     type: RollingUpdate


### PR DESCRIPTION
current deployment.yaml has `quay.io/rh-aiservices-bu/gradio-rag-vllm-pgvector:lastest`, when only `0.0.1` tag is present on [quay.io/rh-aiservices-bu/gradio-rag-vllm-pgvector](quay.io/rh-aiservices-bu/gradio-rag-vllm-pgvector:)