### PR TITLE
update version number to string

### DIFF
--- a/examples/notebooks/langchain/Langchain-Milvus-Ingest-nomic.ipynb
+++ b/examples/notebooks/langchain/Langchain-Milvus-Ingest-nomic.ipynb
@@ -106,7 +106,7 @@
    },
    "outputs": [],
    "source": [
-    "product_version = 2.6\n",
+    "product_version = "2.6"\n",
     "documents = [\n",
     "    \"release_notes\",\n",
     "    \"introduction_to_red_hat_openshift_ai\",\n",

--- a/examples/notebooks/langchain/Langchain-Milvus-Ingest.ipynb
+++ b/examples/notebooks/langchain/Langchain-Milvus-Ingest.ipynb
@@ -101,7 +101,7 @@
    },
    "outputs": [],
    "source": [
-    "product_version = 2.6\n",
+    "product_version = "2.6"\n",
     "documents = [\n",
     "    \"release_notes\",\n",
     "    \"introduction_to_red_hat_openshift_ai\",\n",

--- a/examples/notebooks/langchain/Langchain-PgVector-Ingest.ipynb
+++ b/examples/notebooks/langchain/Langchain-PgVector-Ingest.ipynb
@@ -54,7 +54,7 @@
    },
    "outputs": [],
    "source": [
-    "product_version = 2.6\n",
+    "product_version = \"2.6\"\n",
     "CONNECTION_STRING = \"postgresql+psycopg://user:password@postgresql-server:5432/vectordb\"\n",
     "COLLECTION_NAME = f\"rhoai-doc-{product_version}\""
    ]


### PR DESCRIPTION
When setting the version number to something like 2.10, it gets truncated to 2.1.

The version number should instead be handled as a string to avoid accidental truncation.