### PR TITLE
Add missing dependencies for pgvector ingest example

### DIFF
--- a/examples/notebooks/langchain/Langchain-PgVector-Ingest.ipynb
+++ b/examples/notebooks/langchain/Langchain-PgVector-Ingest.ipynb
@@ -34,7 +34,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install -q pgvector"
+    "!pip install -q pgvector pypdf langchain-community sentence-transformers"
    ]
   },
   {


### PR DESCRIPTION
Adding dependencies that are not included in the Standard Data Science notebook image for the Langchain-PGVector-Ingest notebook