### PR TITLE
Update Containerfile to use latest version of ollama

### DIFF
--- a/llm-servers/ollama/Containerfile
+++ b/llm-servers/ollama/Containerfile
@@ -1,5 +1,5 @@
 ARG GOLANG_VERSION=1.22.1
-ARG OLLAMA_VERSION=v0.2.8
+ARG OLLAMA_VERSION=v0.3.13
 
 # Builder stage
 FROM --platform=linux/amd64 quay.io/centos/centos:stream9 AS cpu-builder-amd64
@@ -20,6 +20,7 @@ RUN yum -y update && \
     git checkout tags/${OLLAMA_VERSION}
 # Build the Ollama binary
 WORKDIR /ollama/llm/generate
+ENV GOARCH=amd64
 RUN OLLAMA_CPU_TARGET="cpu_avx2" sh gen_linux.sh
 ENV CGO_ENABLED 1
 WORKDIR /ollama


### PR DESCRIPTION
This commit updates the container file to use latest version of ollama and also adds 'ENV GOARCH=amd64' to make build successful.