### PR TITLE
Fix typos and correct payload in example

### DIFF
--- a/llm-servers/sbert/README.md
+++ b/llm-servers/sbert/README.md
@@ -59,6 +59,6 @@ A `test_service.ipynb` example is present in the folder to test a connection to 
 Two arguments are available when launching the container:
 
 - `--model-path`: indicates where the model is stored. Defaults to `/mnt/models` for compatibility with OpenShift AI Model Serving.
-- `--trust-remote_code`: may be needed to be set to true for some models. Defaults to `false`.
+- `--trust-remote-code`: may be needed to be set to true for some models. Defaults to `false`.
 
 The environment variable `UVICORN_WORKERS` can also be set to have multiple workers spawned simultaneously (default 1). Useful when you want to maximize the usage of the GPU that will be assigned to a single Pod as the different workers will be able to share the GPU.

--- a/llm-servers/sbert/test_service.ipynb
+++ b/llm-servers/sbert/test_service.ipynb
@@ -21,7 +21,12 @@
     "\n",
     "test_strings = [\"That is a happy dog\",\"That is a very happy person\",\"Today is a sunny day\"]\n",
     "\n",
-    "output = query(API_URL, {\"strings\": test_strings})\n",
+    "payload = {\n",
+    "    \"input\":  test_strings,\n",
+    "    \"model\": \"mode-name\"\n",
+    "}\n",
+    "\n",
+    "output = query(API_URL, payload)\n",
     "\n",
     "print(output)"
    ]

--- a/serving-runtimes/sbert_runtime/README.md
+++ b/serving-runtimes/sbert_runtime/README.md
@@ -36,8 +36,8 @@ Once the stack is installed, adding the runtime is pretty straightforward:
 
 Two arguments are available in the runtime definition:
 
-- `--model_path`: indicates where the model is stored. Defaults to `/mnt/models` for compatibility with OpenShift AI Model Serving.
-- `--trust_remote_code`: may be needed to be set to true for some models. Defaults to `false`.
+- `--model-path`: indicates where the model is stored. Defaults to `/mnt/models` for compatibility with OpenShift AI Model Serving.
+- `--trust-remote-code`: may be needed to be set to true for some models. Defaults to `false`.
 
 The runtime is now available when deploying a model.
 

--- a/serving-runtimes/sbert_runtime/sbert-runtime-cpu.yaml
+++ b/serving-runtimes/sbert_runtime/sbert-runtime-cpu.yaml
@@ -13,7 +13,7 @@ spec:
     - image: quay.io/rh-aiservices-bu/sbert-runtime-cpu:1.2.0
       args:
         - '--model-path=/mnt/models'
-        - '--trust-remote_code=True'
+        - '--trust-remote-code=True'
       name: kserve-container
       ports:
         - containerPort: 8080

--- a/serving-runtimes/sbert_runtime/sbert-runtime.yaml
+++ b/serving-runtimes/sbert_runtime/sbert-runtime.yaml
@@ -13,7 +13,7 @@ spec:
     - image: quay.io/rh-aiservices-bu/sbert-runtime:1.2.0
       args:
         - '--model-path=/mnt/models'
-        - '--trust-remote_code=True'
+        - '--trust-remote-code=True'
       name: kserve-container
       ports:
         - containerPort: 8080


### PR DESCRIPTION
Corrected typos and fixed the payload in the example to match the expected input format for the SBERT runtime.

Fixes #126 