### PR TITLE
Support for AnythingLLM 1.8.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,26 @@
 *.env
 .vscode
 redis_schema.yaml
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Logs
+*.log
+
+# Backup files
+*.bak
+*.backup

--- a/llm-clients/anythingllm/Containerfile
+++ b/llm-clients/anythingllm/Containerfile
@@ -1,4 +1,4 @@
-FROM docker.io/mintplexlabs/anythingllm:1.7.5 as anythingllm
+FROM docker.io/mintplexlabs/anythingllm:1.8.5 as anythingllm
 
 FROM quay.io/sclorg/s2i-core-c9s:c9s
 
@@ -65,9 +65,8 @@ RUN chown -R 1001:0 ${APP_ROOT} && chmod -R ug+rwx ${APP_ROOT} && \
 # Install Chrome for Puppeteer (for web scraping) #
 ###################################################
 
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
-    yum -y install google-chrome-stable_current_x86_64.rpm && \
-    rm -f  google-chrome-stable_current_x86_64.rpm && \
+# Install Chromium instead of Chrome for better architecture support
+RUN yum -y install chromium && \
     yum -y clean all --enablerepo='*' && \
     rm -rf /var/cache/dnf && \
     find /var/log -type f -name "*.log" -exec rm -f {} \;
@@ -140,10 +139,9 @@ COPY --chown=1001:0 nginx/api/ /opt/app-root/api/
 COPY --chown=1001:0 --from=anythingllm /app /app
 RUN chmod -R g+rw /app && \
     chown -R 1001:0 /app && \
-    # Installing Puppeteer Chromium and moving it to a safe container location, we'll link it at runtime
-    node /app/collector/node_modules/puppeteer/install.mjs && \
-    mv /opt/app-root/src/.cache/puppeteer /app/collector/node_modules/puppeteer/.local-chromium && \
-    rm -rf /opt/app-root/src/.cache
+    # Skip Puppeteer's Chromium download since we're using system Chromium
+    echo "Using system Chromium instead of Puppeteer's bundled version" && \
+    mkdir -p /app/collector/node_modules/puppeteer/.local-chromium
 
 ############
 # Launcher #

--- a/llm-clients/anythingllm/collector-processLink-convert_generic.js.patch
+++ b/llm-clients/anythingllm/collector-processLink-convert_generic.js.patch
@@ -1,10 +1,11 @@
 --- collector/processLink/convert/generic.js	2024-09-09 16:38:03.712198992 -0400
 +++ collector/processLink/convert/generic-patched.js	2024-09-09 17:19:02.707115442 -0400
-@@ -57,6 +57,7 @@
+@@ -57,6 +57,8 @@
      const loader = new PuppeteerWebBaseLoader(link, {
        launchOptions: {
          headless: "new",
-+        args: ['--no-sandbox'],
++        args: ['--no-sandbox', '--disable-setuid-sandbox'],
++        executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser',
          ignoreHTTPSErrors: true,
        },
        gotoOptions: {

--- a/llm-clients/anythingllm/collector-utils-extensions-WebsiteDepth_index.js.patch
+++ b/llm-clients/anythingllm/collector-utils-extensions-WebsiteDepth_index.js.patch
@@ -5,7 +5,7 @@
    try {
      const loader = new PuppeteerWebBaseLoader(url, {
 -      launchOptions: { headless: "new" },
-+      launchOptions: { headless: "new", args: ['--no-sandbox'], },
++      launchOptions: { headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'], executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser', },
        gotoOptions: { waitUntil: "networkidle2" },
      });
      const docs = await loader.load();
@@ -14,7 +14,7 @@
      try {
        const loader = new PuppeteerWebBaseLoader(link, {
 -        launchOptions: { headless: "new" },
-+        launchOptions: { headless: "new", args: ['--no-sandbox'], },
++        launchOptions: { headless: "new", args: ['--no-sandbox', '--disable-setuid-sandbox'], executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || '/usr/bin/chromium-browser', },
          gotoOptions: { waitUntil: "networkidle2" },
          async evaluate(page, browser) {
            const result = await page.evaluate(() => document.body.innerText);

--- a/llm-clients/anythingllm/run-anythingllm.sh
+++ b/llm-clients/anythingllm/run-anythingllm.sh
@@ -61,9 +61,9 @@ if [ ! -L "/app/server/.env" ]; then
   ln -s /opt/app-root/src/anythingllm/.env /app/server/.env
 fi
 
-# Link Chromium binary for Puppeteer
-mkdir -p /opt/app-root/src/.cache
-ln -s /app/collector/node_modules/puppeteer/.local-chromium /opt/app-root/src/.cache/puppeteer
+# Link system Chromium binary for Puppeteer
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+export PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 
 export USER=$(whoami)
 


### PR DESCRIPTION
1. Support for **AnythingLLM 1.8.5**
2. Cross-platform compatiblity - works on ARM and x86
3. Use chromium instead of chrome
    * reduce image size
    * better compatibility and maintainance

Changes:
- Updated base image from mintplexlabs/anythingllm:1.7.5 to mintplexlabs/anythingllm:1.8.5
- Updated Puppeteer configuration: Modified to use system Chromium instead of bundled version
- Updated all Puppeteer launch configurations to include proper executable path and sandbox flags